### PR TITLE
use standard sqlite3 binary location

### DIFF
--- a/data/mksql3db.sh
+++ b/data/mksql3db.sh
@@ -6,7 +6,7 @@
 
 MYNAME=$(basename $0)
 #SQ3=/usr/local/android-sdk-linux/tools/sqlite3
-SQ3=/opt/adt-bundle-linux-x86_64-20131030/sdk/tools/sqlite3
+SQ3=/usr/bin/sqlite3
 
 function usage {
     echo "Usage: $MYNAME dbname file [file ...]"


### PR DESCRIPTION
having it point to an old android SDK binary won't fit most people's use cases
/usr/bin/sqlite3 would be a common location for this binary on linux