### PR TITLE
Increase Portability to BSD

### DIFF
--- a/data/mksql3db.sh
+++ b/data/mksql3db.sh
@@ -93,8 +93,8 @@ do
     stops.txt)
 	    table=$(echo `basename $file` | sed -e 's/\..*//')
 	    columns="stop_sorted,$(cat $file | tr -d '\015' | head -n 1 | sed -e '1 s/^\xef\xbb\xbf//')"
-	    #tail -n +2 "$file" | sort -k6 -g -t, | cat -n -s | awk '{ $1 = $1","; print}' > $tmpfile
-	    tail -n +2 $file | awk '{$1=$1};1' | sort -k6 -g -t, | grep -n '^' - | sed -e '/^$/d' | sed -e 's/,\ */,/g' | sed -e 's/\([0-9]\):/\1,/g' > $tmpfile
+	    #tail -n +2 "$file" | sort -k6 -n -t, | cat -n -s | awk '{ $1 = $1","; print}' > $tmpfile
+	    tail -n +2 $file | awk '{$1=$1};1' | sort -k6 -n -t, | grep -n '^' - | sed -e '/^$/d' | sed -e 's/,\ */,/g' | sed -e 's/\([0-9]\):/\1,/g' > $tmpfile
 	    (
 		echo "create table $table($columns);"
 		echo ".separator ,"
@@ -242,7 +242,9 @@ mv $DB.version $DB.version.old
 gzip -9v -c $DB > $DB.gz
 
 md5=$(md5sum $DB | cut -f1 -d' ')
+#md5=$(md5 -q $DB)
 size=$(stat -c "%s" $DB.gz)
+#size=$(stat -f "%z" $DB.gz)
 sizem=$(echo "1k $size 512+ 1024/1024/p" | dc)
 echo "$version $sizem $md5" > $DB.version
 


### PR DESCRIPTION
As  described in the info page for GNU sort:

> ‘-g’
> ‘--general-numeric-sort’
> ‘--sort=general-numeric’
>      Sort numerically, converting a prefix of each line to a long
>      double-precision floating point number.  *Note Floating point::.
>      Do not report overflow, underflow, or conversion errors.  Use the
>      following collating sequence:
> 
>  * Lines that do not start with numbers (all considered to be equal).
>  * NaNs (“Not a Number” values, in IEEE floating point  arithmetic) in a consistent but machine-dependent order.
> * Minus infinity.
>  * Finite numbers in ascending numeric order (with -0 and + equal).
> * Plus infinity.
> 
>  Use this option only if there is no alternative; it is much slower
>  than ‘--numeric-sort’ (‘-n’) and it can lose information when
>  converting to floating point.

It, however, is not portable.

md5sum and the flags for stat also aren't portable. I added commented out versions that work on NetBSD but, since an error at that point doesn't prevent the process from completing, I didn't bother with a more robust solution.


